### PR TITLE
Breaking Change: export splitSentences as split function

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Split {Japanese, English} text into sentences.
 - `splitSentences(text, [options])`: `Node[]`
 
 ```js
-import splitSentences from "sentence-splitter";
-let sentences = splitSentences("text.\n\ntext");
+import {split, Syntax} from "sentence-splitter";
+let sentences = split("text.\n\ntext");
 console.log(JSON.stringify(sentences, null, 4));
 /*
 [
@@ -96,7 +96,7 @@ console.log(JSON.stringify(sentences, null, 4));
 */
 
 // with splitting char options
-let sentences = splitSentences("text¶text", {
+let sentences = split("text¶text", {
     charRegExp: /¶/
 });
 sentences.length; // 2
@@ -121,6 +121,12 @@ See more detail on [Why do `line` of location in JavaScript AST(ESTree) start wi
 
 - `Sentence`: Sentence Node contain punctuation.
 - `WhiteSpace`: WhiteSpace Node has `\n`.
+
+Get these `Syntax` constants value from the module:
+
+```js
+import {Syntax} from "sentence-splitter";
+console.log(Syntax.Sentence);// "Sentence"
 
 ### Treat Markdown break line
 
@@ -184,7 +190,7 @@ let text = `TextA
 TextB
            
 TextC`;
-let sentences = splitSentences(text, {
+let sentences = split(text, {
     newLineCharacters: "\n\n" // `\n\n` as a separator
 });
 console.log(JSON.stringify(sentences, null, 4))

--- a/src/sentence-splitter.js
+++ b/src/sentence-splitter.js
@@ -9,7 +9,7 @@ export const Syntax = {
     "WhiteSpace": "WhiteSpace",
     "Sentence": "Sentence"
 };
-export default function splitSentences(text, options = {}) {
+export function split(text, options = {}) {
     const matchChar = options.charRegExp || defaultOptions.charRegExp;
     const newLineCharacters = options.newLineCharacters || defaultOptions.newLineCharacters;
     const src = new StructureSource(text);

--- a/test/sentence-utils-test.js
+++ b/test/sentence-utils-test.js
@@ -1,6 +1,5 @@
 import assert from "power-assert";
-import splitSentences from "../src/sentence-splitter";
-import {Syntax} from "../src/sentence-splitter";
+import {Syntax, split as splitSentences} from "../src/sentence-splitter";
 describe("sentence-utils", function () {
     it("should return array", function () {
         let sentences = splitSentences("text");


### PR DESCRIPTION
It contain Breaking Change.

Before:

```js
import splitSentences from "sentence-splitter"
```

After:

```js
import {split} from "sentence-splitter"
```

Because I want to avoid mixed default export and named export.