### PR TITLE
feat: add `separatorChars` insteadof `charRegExp` option

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,6 +6,9 @@
     "development": {
       "plugins": [
         "jsdoc-to-assert"
+      ],
+      "presets": [
+        "power-assert"
       ]
     }
   }

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ console.log(JSON.stringify(sentences, null, 4));
 
 // with splitting char options
 let sentences = split("text¶text", {
-    charRegExp: /¶/
+    splitChars: ["¶"]
 });
 sentences.length; // 2
 ```
@@ -117,7 +117,10 @@ See more detail on [Why do `line` of location in JavaScript AST(ESTree) start wi
 
 ### Options
 
-- `charRegExp`
+- `splitChars`
+    - [".", "。", "?", "!", "？", "！"]
+    - separator chars of sentences.
+- `charRegExp` (**Deprecated**)
     - default: `/[\.。\?\!？！]/`
     - separator of sentences.
 - `newLineCharacters`
@@ -135,6 +138,7 @@ Get these `Syntax` constants value from the module:
 ```js
 import {Syntax} from "sentence-splitter";
 console.log(Syntax.Sentence);// "Sentence"
+````
 
 ### Treat Markdown break line
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ console.log(JSON.stringify(sentences, null, 4));
 
 // with splitting char options
 let sentences = split("text¶text", {
-    splitChars: ["¶"]
+    separatorChars: ["¶"]
 });
 sentences.length; // 2
 ```
@@ -117,7 +117,7 @@ See more detail on [Why do `line` of location in JavaScript AST(ESTree) start wi
 
 ### Options
 
-- `splitChars`
+- `separatorChars`
     - [".", "。", "?", "!", "？", "！"]
     - separator chars of sentences.
 - `charRegExp` (**Deprecated**)

--- a/package.json
+++ b/package.json
@@ -45,8 +45,9 @@
     "babel-plugin-jsdoc-to-assert": "^1.3.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.1.18",
     "babel-preset-es2015": "^6.1.18",
-    "espower-babel": "^4.0.0",
+    "babel-preset-power-assert": "^1.0.0",
+    "babel-register": "^6.18.0",
     "mocha": "^2.3.3",
-    "power-assert": "^1.1.0"
+    "power-assert": "^1.4.2"
   }
 }

--- a/src/sentence-splitter.js
+++ b/src/sentence-splitter.js
@@ -1,8 +1,12 @@
 // LICENSE : MIT
 "use strict";
+const assert = require("assert");
 import StructureSource from "structured-source";
 const defaultOptions = {
+    // charRegExp is deprecated
     charRegExp: /[\.。\?\!？！]/,
+    // separator char list
+    splitChars: [".", "。", "?", "!", "？", "！"],
     newLineCharacters: "\n"
 };
 export const Syntax = {
@@ -13,15 +17,19 @@ export const Syntax = {
  * @param {string} text
  * @param {{
  *      charRegExp: ?Object,
+ *      splitChars: ?string[],
  *      newLineCharacters: ?String
  *  }} options
  * @returns {Array}
  */
 export function split(text, options = {}) {
-    const matchChar = options.charRegExp || defaultOptions.charRegExp;
+    const charRegExp = options.charRegExp;
+    const splitChars = options.splitChars || defaultOptions.splitChars;
+    assert(!(options.charRegExp && options.splitChars), "should use either one `charRegExp` or `splitChars`.\n"
+        + "`charRegExp` is deprecated.");
     const newLineCharacters = options.newLineCharacters || defaultOptions.newLineCharacters;
     const src = new StructureSource(text);
-    let createNode = (type, start, end)=> {
+    let createNode = (type, start, end) => {
         let range = [start, end];
         let location = src.rangeToLocation(range);
         let slicedText = text.slice(start, end);
@@ -54,7 +62,7 @@ export function split(text, options = {}) {
             // string\n|
             startPoint = currentIndex + newLineCharactersLength;
             isSplitPoint = false;
-        } else if (matchChar.test(char)) {
+        } else if ((charRegExp && charRegExp.test(char)) || splitChars.indexOf(char) !== -1) {
             isSplitPoint = true;
         } else {
             // why `else`

--- a/src/sentence-splitter.js
+++ b/src/sentence-splitter.js
@@ -6,7 +6,7 @@ const defaultOptions = {
     // charRegExp is deprecated
     charRegExp: /[\.。\?\!？！]/,
     // separator char list
-    splitChars: [".", "。", "?", "!", "？", "！"],
+    separatorChars: [".", "。", "?", "!", "？", "！"],
     newLineCharacters: "\n"
 };
 export const Syntax = {
@@ -17,16 +17,27 @@ export const Syntax = {
  * @param {string} text
  * @param {{
  *      charRegExp: ?Object,
- *      splitChars: ?string[],
+ *      separatorChars: ?string[],
  *      newLineCharacters: ?String
  *  }} options
  * @returns {Array}
  */
 export function split(text, options = {}) {
     const charRegExp = options.charRegExp;
-    const splitChars = options.splitChars || defaultOptions.splitChars;
-    assert(!(options.charRegExp && options.splitChars), "should use either one `charRegExp` or `splitChars`.\n"
+    const separatorChars = options.separatorChars || defaultOptions.separatorChars;
+    assert(!(options.charRegExp && options.separatorChars), "should use either one `charRegExp` or `separatorChars`.\n"
         + "`charRegExp` is deprecated.");
+    /**
+     * Is the `char` separator symbol?
+     * @param {string} char
+     * @returns {boolean}
+     */
+    const testCharIsSeparator = (char) => {
+        if (charRegExp) {
+            return charRegExp.test(char);
+        }
+        return separatorChars.indexOf(char) !== -1;
+    };
     const newLineCharacters = options.newLineCharacters || defaultOptions.newLineCharacters;
     const src = new StructureSource(text);
     let createNode = (type, start, end) => {
@@ -62,7 +73,7 @@ export function split(text, options = {}) {
             // string\n|
             startPoint = currentIndex + newLineCharactersLength;
             isSplitPoint = false;
-        } else if ((charRegExp && charRegExp.test(char)) || splitChars.indexOf(char) !== -1) {
+        } else if (testCharIsSeparator(char)) {
             isSplitPoint = true;
         } else {
             // why `else`

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,1 @@
---compilers js:espower-babel/guess
+--compilers js:babel-register

--- a/test/sentence-utils-test.js
+++ b/test/sentence-utils-test.js
@@ -163,7 +163,7 @@ describe("sentence-utils", function() {
             assert.deepEqual(sentence1.loc.start, {line: 1, column: 5});
             assert.deepEqual(sentence1.loc.end, {line: 1, column: 9});
         });
-        it("should not set splitChars and charRegExp", function() {
+        it("should not set separatorChars and charRegExp", function() {
             try {
                 splitSentences("text¶text", {
                     separatorChars: ["¶"],

--- a/test/sentence-utils-test.js
+++ b/test/sentence-utils-test.js
@@ -1,7 +1,7 @@
 import assert from "power-assert";
 import {Syntax, split as splitSentences} from "../src/sentence-splitter";
-describe("sentence-utils", function () {
-    it("should return array", function () {
+describe("sentence-utils", function() {
+    it("should return array", function() {
         let sentences = splitSentences("text");
         assert.equal(sentences.length, 1);
         let sentence = sentences[0];
@@ -10,7 +10,7 @@ describe("sentence-utils", function () {
         assert.deepEqual(sentences[0].loc.start, {line: 1, column: 0});
         assert.deepEqual(sentences[0].loc.end, {line: 1, column: 4});
     });
-    it("should return sentences split by first line break", function () {
+    it("should return sentences split by first line break", function() {
         let sentences = splitSentences("\ntext");
         assert.equal(sentences.length, 2);
         var whiteSpace0 = sentences[0];
@@ -24,7 +24,7 @@ describe("sentence-utils", function () {
         assert.deepEqual(sentence1.loc.start, {line: 2, column: 0});
         assert.deepEqual(sentence1.loc.end, {line: 2, column: 4});
     });
-    it("should return sentences split by last line break", function () {
+    it("should return sentences split by last line break", function() {
         let sentences = splitSentences("text\n");
         assert.equal(sentences.length, 2);
         var sentence0 = sentences[0];
@@ -38,7 +38,7 @@ describe("sentence-utils", function () {
         assert.deepEqual(whiteSpace1.loc.start, {line: 1, column: 4});
         assert.deepEqual(whiteSpace1.loc.end, {line: 2, column: 0});
     });
-    it("should return sentences split by line break*2", function () {
+    it("should return sentences split by line break*2", function() {
         let sentences = splitSentences("text\n\ntext");
         assert.equal(sentences.length, 4);
         var sentence0 = sentences[0];
@@ -63,7 +63,7 @@ describe("sentence-utils", function () {
         assert.deepEqual(sentence3.loc.end, {line: 3, column: 4});
 
     });
-    it("should return sentences split by 。", function () {
+    it("should return sentences split by 。", function() {
         let sentences = splitSentences("text。。text");
         assert.equal(sentences.length, 2);
         var sentence0 = sentences[0];
@@ -75,7 +75,7 @@ describe("sentence-utils", function () {
         assert.deepEqual(sentence1.loc.start, {line: 1, column: 6});
         assert.deepEqual(sentence1.loc.end, {line: 1, column: 10});
     });
-    it("should return sentences split by 。 and linebreak", function () {
+    it("should return sentences split by 。 and linebreak", function() {
         let sentences = splitSentences("text。\ntext");
         assert.equal(sentences.length, 3);
         var sentence0 = sentences[0];
@@ -91,7 +91,7 @@ describe("sentence-utils", function () {
         assert.deepEqual(sentence2.loc.start, {line: 2, column: 0});
         assert.deepEqual(sentence2.loc.end, {line: 2, column: 4});
     });
-    it("should return sentences split by !?", function () {
+    it("should return sentences split by !?", function() {
         let sentences = splitSentences("text!?text");
         assert.equal(sentences.length, 2);
         var sentence0 = sentences[0];
@@ -103,7 +103,7 @@ describe("sentence-utils", function () {
         assert.deepEqual(sentence1.loc.start, {line: 1, column: 6});
         assert.deepEqual(sentence1.loc.end, {line: 1, column: 10});
     });
-    it("should sentences split by last 。", function () {
+    it("should sentences split by last 。", function() {
         let sentences = splitSentences("text。");
         assert.equal(sentences.length, 1);
         let sentence = sentences[0];
@@ -111,8 +111,8 @@ describe("sentence-utils", function () {
         assert.deepEqual(sentences[0].loc.start, {line: 1, column: 0});
         assert.deepEqual(sentences[0].loc.end, {line: 1, column: 5});
     });
-    context("with options", function () {
-        it("should separate by whiteSpace", function () {
+    context("with options", function() {
+        it("should separate by whiteSpace", function() {
             var options = {
                 newLineCharacters: "\n\n"
             };
@@ -135,7 +135,7 @@ describe("sentence-utils", function () {
             assert.deepEqual(sentence3.loc.start, {line: 3, column: 0});
             assert.deepEqual(sentence3.loc.end, {line: 3, column: 4});
         });
-        it("should separate by charRegExp", function () {
+        it("should separate by charRegExp", function() {
             let sentences = splitSentences("text¶text", {
                 charRegExp: /¶/
             });
@@ -148,6 +148,31 @@ describe("sentence-utils", function () {
             assert.strictEqual(sentence1.raw, "text");
             assert.deepEqual(sentence1.loc.start, {line: 1, column: 5});
             assert.deepEqual(sentence1.loc.end, {line: 1, column: 9});
+        });
+        it("should separate by splitChars", function() {
+            let sentences = splitSentences("text¶text", {
+                splitChars: ["¶"]
+            });
+            assert.equal(sentences.length, 2);
+            var sentence0 = sentences[0];
+            assert.strictEqual(sentence0.raw, "text¶");
+            assert.deepEqual(sentence0.loc.start, {line: 1, column: 0});
+            assert.deepEqual(sentence0.loc.end, {line: 1, column: 5});
+            var sentence1 = sentences[1];
+            assert.strictEqual(sentence1.raw, "text");
+            assert.deepEqual(sentence1.loc.start, {line: 1, column: 5});
+            assert.deepEqual(sentence1.loc.end, {line: 1, column: 9});
+        });
+        it("should not set splitChars and charRegExp", function() {
+            try {
+                splitSentences("text¶text", {
+                    splitChars: ["¶"],
+                    charRegExp: /¶/
+                });
+                throw new Error("FAIL");
+            } catch (error) {
+                assert.equal(error.name, "AssertionError");
+            }
         });
     });
 });

--- a/test/sentence-utils-test.js
+++ b/test/sentence-utils-test.js
@@ -151,7 +151,7 @@ describe("sentence-utils", function() {
         });
         it("should separate by splitChars", function() {
             let sentences = splitSentences("text¶text", {
-                splitChars: ["¶"]
+                separatorChars: ["¶"]
             });
             assert.equal(sentences.length, 2);
             var sentence0 = sentences[0];
@@ -166,7 +166,7 @@ describe("sentence-utils", function() {
         it("should not set splitChars and charRegExp", function() {
             try {
                 splitSentences("text¶text", {
-                    splitChars: ["¶"],
+                    separatorChars: ["¶"],
                     charRegExp: /¶/
                 });
                 throw new Error("FAIL");


### PR DESCRIPTION
`charRegExp` is deprecated.
It will be removed next major update.


```js
split({
  separatorChars: [".", "。", "?", "!", "？", "！"]
});
```