### PR TITLE
Support Guillemets

### DIFF
--- a/src/parser/PairMaker.ts
+++ b/src/parser/PairMaker.ts
@@ -20,7 +20,8 @@ export class PairMaker implements AbstractMarker {
         [`（`]: `）`,
         [`(`]: `)`,
         [`『`]: `』`,
-        [`【`]: `】`
+        [`【`]: `】`,
+        [`《`]: `》`
     };
     private pairKeys = Object.keys(this.pairs);
     private pairValues = values(this.pairs);

--- a/test/pragmatic_segmenter/test.ts
+++ b/test/pragmatic_segmenter/test.ts
@@ -412,6 +412,12 @@ export const source = [
     },
 
     {
+        name: "Guillemet",
+        input: "《響け！ユーフォニアム》は京都アニメーションの有名作品です。",
+        output: ["《響け！ユーフォニアム》は京都アニメーションの有名作品です。"]
+    },
+
+    {
         name: "Errant newlines in the middle of sentences",
         input: "これは父の\n家です。",
         output: ["これは父の家です。"],


### PR DESCRIPTION
According to the Wikipedia, guillemets are used to indicate book or album
titles.

Reference:
https://en.wikipedia.org/wiki/Guillemet#Uses