### PR TITLE
feat(SeparatorParser): add SeparatorParser options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,29 @@ Split {Japanese, English} text into sentences.
 ## Usage
 
 ```ts
+export interface SeparatorParserOptions {
+    /**
+     * Recognize each characters as separator
+     * Example [".", "!", "?"]
+     */
+    separatorCharacters?: string[]
+}
+export interface splitOptions {
+    /**
+     * Separator options
+     */
+    SeparatorParser?: SeparatorParserOptions;
+}
 /**
- * split `text` into Sentence node list.
+ * split `text` into Sentence nodes
  */
-export declare function split(text: string): (TxtParentNode | TxtNode)[];
+export declare function split(text: string, options?: splitOptions): (TxtParentNode | TxtNode)[];
 /**
  * Convert Paragraph Node to Paragraph node that convert children to Sentence node
  * This Node is based on TxtAST.
  * See https://github.com/textlint/textlint/blob/master/docs/txtnode.md
  */
-export declare function splitAST(paragraphNode: TxtParentNode): TxtParentNode;
+export declare function splitAST(paragraphNode: TxtParentNode, options?: splitOptions): TxtParentNode;
 ```
 
 `TxtParentNode` and `TxtNode` is defined in [TxtAST](https://github.com/textlint/textlint/blob/master/docs/txtnode.md "TxtAST").

--- a/src/parser/SeparatorParser.ts
+++ b/src/parser/SeparatorParser.ts
@@ -1,12 +1,37 @@
 import { SourceCode } from "./SourceCode";
 import { AbstractParser } from "./AbstractParser";
 
-const separatorPattern = /[.．。?!？！]/;
+export const DefaultOptions = {
+    separatorCharacters: [
+        ".", // period
+        "．", // (ja) zenkaku-period
+        "。", // (ja) dokuten
+        "?", // question mark
+        "!", //  exclamation mark
+        "？", // (ja) zenkaku question mark
+        "！" // (ja) zenkaku exclamation mark
+    ]
+};
+
+export interface SeparatorParserOptions {
+    /**
+     * Recognize each characters as separator
+     * Example [".", "!", "?"]
+     */
+    separatorCharacters?: string[];
+}
 
 /**
  * Separator parser
  */
 export class SeparatorParser implements AbstractParser {
+    private separatorCharacters: string[];
+
+    constructor(readonly options?: SeparatorParserOptions) {
+        this.separatorCharacters =
+            options && options.separatorCharacters ? options.separatorCharacters : DefaultOptions.separatorCharacters;
+    }
+
     test(sourceCode: SourceCode) {
         if (sourceCode.isInContext()) {
             return false;
@@ -19,7 +44,7 @@ export class SeparatorParser implements AbstractParser {
         if (!firstChar) {
             return false;
         }
-        if (!separatorPattern.test(firstChar)) {
+        if (!this.separatorCharacters.includes(firstChar)) {
             return false;
         }
         // Need space after period

--- a/test/fixtures-test.ts
+++ b/test/fixtures-test.ts
@@ -10,8 +10,10 @@ describe("fixtures testing", () => {
         it(`Test ${caseName.replace(/-/g, " ")}`, function() {
             const fixtureDir = path.join(fixturesDir, caseName);
             const actualPath = path.join(fixtureDir, "input.json");
+            const optionsPath = path.join(fixtureDir, "options.js");
             const actualContent: TxtParentNode = JSON.parse(fs.readFileSync(actualPath, "utf-8"));
-            const actual = splitAST(actualContent);
+            const splitOptions = fs.existsSync(optionsPath) ? require(optionsPath) : {};
+            const actual = splitAST(actualContent, splitOptions);
             const outputFilePath = path.join(fixtureDir, "output.json");
             if (process.env.UPDATE_SNAPSHOT) {
                 fs.writeFileSync(outputFilePath, JSON.stringify(actual, null, 4));

--- a/test/fixtures/options.SeparatorParser/_input.md
+++ b/test/fixtures/options.SeparatorParser/_input.md
@@ -1,0 +1,4 @@
+Hello! Tom!
+Hello! Tom.
+Hello!?Tom.
+こんにちわ、Tom。

--- a/test/fixtures/options.SeparatorParser/input.json
+++ b/test/fixtures/options.SeparatorParser/input.json
@@ -1,0 +1,39 @@
+{
+  "type": "Paragraph",
+  "children": [
+    {
+      "type": "Str",
+      "value": "Hello! Tom!\nHello! Tom.\nHello!?Tom.\nこんにちわ、Tom。",
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 4,
+          "column": 10
+        }
+      },
+      "range": [
+        0,
+        46
+      ],
+      "raw": "Hello! Tom!\nHello! Tom.\nHello!?Tom.\nこんにちわ、Tom。"
+    }
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 4,
+      "column": 10
+    }
+  },
+  "range": [
+    0,
+    46
+  ],
+  "raw": "Hello! Tom!\nHello! Tom.\nHello!?Tom.\nこんにちわ、Tom。"
+}

--- a/test/fixtures/options.SeparatorParser/options.js
+++ b/test/fixtures/options.SeparatorParser/options.js
@@ -1,0 +1,10 @@
+/**
+ * @type {splitOptions}
+ */
+module.exports = {
+    SeparatorParser: {
+        // separator is 。
+        // input.json sentence should be 1 sentence
+        separatorCharacters: ["。"]
+    }
+};

--- a/test/fixtures/options.SeparatorParser/output.json
+++ b/test/fixtures/options.SeparatorParser/output.json
@@ -1,0 +1,192 @@
+{
+    "type": "Paragraph",
+    "children": [
+        {
+            "type": "Sentence",
+            "raw": "Hello! Tom!\nHello! Tom.\nHello!?Tom.\nこんにちわ、Tom。",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 4,
+                    "column": 10
+                }
+            },
+            "range": [
+                0,
+                46
+            ],
+            "children": [
+                {
+                    "type": "Str",
+                    "raw": "Hello! Tom!",
+                    "value": "Hello! Tom!",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 11
+                        }
+                    },
+                    "range": [
+                        0,
+                        11
+                    ]
+                },
+                {
+                    "type": "WhiteSpace",
+                    "raw": "\n",
+                    "value": "\n",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 11
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 0
+                        }
+                    },
+                    "range": [
+                        11,
+                        12
+                    ]
+                },
+                {
+                    "type": "Str",
+                    "raw": "Hello! Tom.",
+                    "value": "Hello! Tom.",
+                    "loc": {
+                        "start": {
+                            "line": 2,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 11
+                        }
+                    },
+                    "range": [
+                        12,
+                        23
+                    ]
+                },
+                {
+                    "type": "WhiteSpace",
+                    "raw": "\n",
+                    "value": "\n",
+                    "loc": {
+                        "start": {
+                            "line": 2,
+                            "column": 11
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 0
+                        }
+                    },
+                    "range": [
+                        23,
+                        24
+                    ]
+                },
+                {
+                    "type": "Str",
+                    "raw": "Hello!?Tom.",
+                    "value": "Hello!?Tom.",
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 11
+                        }
+                    },
+                    "range": [
+                        24,
+                        35
+                    ]
+                },
+                {
+                    "type": "WhiteSpace",
+                    "raw": "\n",
+                    "value": "\n",
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 11
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 0
+                        }
+                    },
+                    "range": [
+                        35,
+                        36
+                    ]
+                },
+                {
+                    "type": "Str",
+                    "raw": "こんにちわ、Tom",
+                    "value": "こんにちわ、Tom",
+                    "loc": {
+                        "start": {
+                            "line": 4,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 9
+                        }
+                    },
+                    "range": [
+                        36,
+                        45
+                    ]
+                },
+                {
+                    "type": "Punctuation",
+                    "raw": "。",
+                    "value": "。",
+                    "loc": {
+                        "start": {
+                            "line": 4,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 10
+                        }
+                    },
+                    "range": [
+                        45,
+                        46
+                    ]
+                }
+            ]
+        }
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 4,
+            "column": 10
+        }
+    },
+    "range": [
+        0,
+        46
+    ],
+    "raw": "Hello! Tom!\nHello! Tom.\nHello!?Tom.\nこんにちわ、Tom。"
+}


### PR DESCRIPTION
- Allow to set `separatorCharacters`

Related https://github.com/textlint-ja/textlint-rule-no-doubled-joshi/issues/25